### PR TITLE
Use forward slashes in manifest paths regardless of platform.

### DIFF
--- a/tasks/noflo_manifest.js
+++ b/tasks/noflo_manifest.js
@@ -91,7 +91,7 @@ module.exports = function(grunt) {
           return;
         }
         var ext = path.extname(filepath);
-        var localPath = path.relative(path.dirname(f.dest), filepath);
+        var localPath = path.relative(path.dirname(f.dest), filepath).replace(path.sep, '/');
         var graphData, componentData;
         if (ext === '.json') {
           // Graph


### PR DESCRIPTION
Fixes #2.
